### PR TITLE
Update beagleplay-ti-mender.yml by removing settings

### DIFF
--- a/yml/beagleplay-ti-mender.yml
+++ b/yml/beagleplay-ti-mender.yml
@@ -30,10 +30,7 @@ local_conf_header:
     MENDER_ARTIFACT_NAME = "${IMAGE_BASENAME}-${MACHINE}-UUID_SLUG"
 
   bitbake-caching: |
-    BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
     SSTATE_MIRRORS ?= "file://.* https://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
-    BB_HASHSERVE = "auto"
-    BB_SIGNATURE_HANDLER = "OEEquivHash"
 
 target:
   - core-image-full-cmdline


### PR DESCRIPTION
Removed BB_HASHSERVE_UPSTREAM, BB_HASHSERVE, and BB_SIGNATURE_HANDLER from bitbake-caching.